### PR TITLE
all: rename module name to opentofu/equivalence-testing and sort imports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/opentffoundation/equivalence-testing
+module github.com/opentofu/equivalence-testing
 
 go 1.18
 

--- a/internal/binary/terraform.go
+++ b/internal/binary/terraform.go
@@ -9,9 +9,9 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/opentffoundation/equivalence-testing/internal/files"
-
 	"github.com/hashicorp/terraform-exec/tfexec"
+
+	"github.com/opentofu/equivalence-testing/internal/files"
 )
 
 // Command is a struct that instructs the framework how to execute a custom

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -12,8 +12,8 @@ import (
 	"github.com/komkom/jsonc/jsonc"
 	"github.com/mitchellh/cli"
 
-	"github.com/opentffoundation/equivalence-testing/internal/binary"
-	"github.com/opentffoundation/equivalence-testing/internal/tests"
+	"github.com/opentofu/equivalence-testing/internal/binary"
+	"github.com/opentofu/equivalence-testing/internal/tests"
 )
 
 func UpdateCommandFactory(ui cli.Ui) cli.CommandFactory {

--- a/internal/tests/output.go
+++ b/internal/tests/output.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/opentffoundation/equivalence-testing/internal/files"
-	strip "github.com/opentffoundation/equivalence-testing/internal/json"
+	"github.com/opentofu/equivalence-testing/internal/files"
+	strip "github.com/opentofu/equivalence-testing/internal/json"
 )
 
 const (

--- a/internal/tests/specification.go
+++ b/internal/tests/specification.go
@@ -3,7 +3,7 @@
 
 package tests
 
-import "github.com/opentffoundation/equivalence-testing/internal/binary"
+import "github.com/opentofu/equivalence-testing/internal/binary"
 
 // TestSpecification is a struct that provides the specification for a given
 // test case.

--- a/internal/tests/tests.go
+++ b/internal/tests/tests.go
@@ -10,8 +10,9 @@ import (
 	"path/filepath"
 
 	"github.com/komkom/jsonc/jsonc"
-	"github.com/opentffoundation/equivalence-testing/internal/binary"
-	"github.com/opentffoundation/equivalence-testing/internal/files"
+
+	"github.com/opentofu/equivalence-testing/internal/binary"
+	"github.com/opentofu/equivalence-testing/internal/files"
 )
 
 // Test defines a single equivalence test within our framework.

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/mitchellh/cli"
 
-	"github.com/opentffoundation/equivalence-testing/internal/cmd"
+	"github.com/opentofu/equivalence-testing/internal/cmd"
 )
 
 var (


### PR DESCRIPTION
OpenTofu organization has been renamed from `opentffoundation`, but there is still use of the previous name in the Go module.
Rename it and sort the import section via `goimports`.

Same as https://github.com/opentofu/registry/pull/74.